### PR TITLE
add IncorrectPasswordError

### DIFF
--- a/packages/graphql-authentication/src/errors.ts
+++ b/packages/graphql-authentication/src/errors.ts
@@ -20,6 +20,10 @@ export const UserNotFoundError = createError('UserNotFoundError', {
   message: 'No user found.'
 });
 
+export const IncorrectPasswordError = createError('IncorrectPasswordError', {
+  message: 'Password is incorrect.'
+});
+
 export const InvalidInviteTokenError = createError('InvalidInviteTokenError', {
   message: 'inviteToken is invalid.'
 });

--- a/packages/graphql-authentication/src/mutations.ts
+++ b/packages/graphql-authentication/src/mutations.ts
@@ -10,6 +10,7 @@ import {
   InvalidEmailError,
   PasswordTooShortError,
   UserNotFoundError,
+  IncorrectPasswordError,
   InvalidInviteTokenError,
   UserEmailExistsError,
   UserInviteNotAcceptedError,
@@ -195,7 +196,7 @@ export const mutations = {
 
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) {
-      throw new UserNotFoundError();
+      throw new IncorrectPasswordError();
     }
 
     // Purposefully async, this update doesn't matter that much.


### PR DESCRIPTION
Closes: #45

I believe that it's valuable to distinguish between login failures due to incorrect email vs. incorrect password. This PR adds a new Error subclass to make that distinction.

Alternatively, this can be made as an opt-in if it wouldn't generally be required - if this is the case, let me know and I will revise the PR.